### PR TITLE
Bump bootstrap from 4.0.0-beta.2 to 4.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "webpack-merge": "^4.1.1"
   },
   "dependencies": {
-    "bootstrap": "4.0.0-beta.2",
+    "bootstrap": "4.0.0",
     "loglevel": "^1.6.0"
   }
 }


### PR DESCRIPTION
Simple pull request for bumping the bootstrap version.