### PR TITLE
adding forceWatch option to elm-webpack-loader

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -94,7 +94,8 @@ if (MODE === "development") {
                             loader: "elm-webpack-loader",
                             // add Elm's debug overlay to output
                             options: {
-                                debug: true
+                                debug: true,
+                                forceWatch: true
                             }
                         }
                     ]


### PR DESCRIPTION
Main.elm triggered out of the box, needed this forceWatch flag to get HMR working on App.elm